### PR TITLE
Travis CI from build to nuget

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: csharp
+dist: bionic
+mono: none
+dotnet: 3.1.100
+install:
+ - dotnet restore
+
+jobs:
+  include:
+    - stage: build
+      script: dotnet build
+    - stage: test
+      script: dotnet test
+    - stage: pack-nuget
+      script:
+        - cd ./BunnyCDN.Net.Storage/
+        - dotnet pack -c Release -p:PackageVersion=$TRAVIS_TAG
+        - dotnet nuget push "./bin/Release/*.nupkg" -k "$NUGET_KEY" -s "https://api.nuget.org/v3/index.json"
+      if: tag =~ ^*.*.*$

--- a/BunnyCDN.Net.Storage/BunnyCDN.Net.Storage.csproj
+++ b/BunnyCDN.Net.Storage/BunnyCDN.Net.Storage.csproj
@@ -2,6 +2,13 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+
+    <Authors>BunnyWay</Authors>
+    <Description>The official .NET library used for interacting with the BunnyCDN Storage API.</Description>
+    <PackageId>BunnyCDN.Net.Storage</PackageId>
+    <PackageTags>BunnyCDN API storage async netstandard</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/BunnyWay/BunnyCDN.Net.Storage</PackageProjectUrl>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I've created a travis ci config and updated the csproj to contain the correct values to be packaged.
Using the tag name as version it should be easy to apply. 

The only thing still left to do is merge, add the project to travis ci and set the NUGET_KEY environment variable to the appropriate key. This should do the trick.